### PR TITLE
libft: merge patch from Liewe to make memset faster 

### DIFF
--- a/subprojects/libft/src/ft_memset.c
+++ b/subprojects/libft/src/ft_memset.c
@@ -14,9 +14,25 @@
 
 void	*ft_memset(void *b, int c, size_t len)
 {
-	size_t	i;
+	size_t				i;
+	size_t				chunk_size;
+	unsigned long long	chunk;
 
+	chunk = 0;
+	chunk_size = sizeof(unsigned long long);
+	i = chunk_size / sizeof(unsigned char);
+	while (i > 0)
+	{
+		chunk <<= 8;
+		chunk |= (unsigned long long)(unsigned char)c;
+		i--;
+	}
 	i = 0;
+	while (len >= chunk_size && i < (len - chunk_size))
+	{
+		*(unsigned long long *)&(((unsigned char *)b)[i]) = chunk;
+		i += chunk_size;
+	}
 	while (i < len)
 	{
 		((unsigned char *)b)[i] = (unsigned char)c;


### PR DESCRIPTION
@lgutter made the following change to libft

> made memset significantly faster for very long strings.
>
> Memory will now be set in chunks of the size of an unsigned long long,
> until there are less characters left than the chunk size.