### PR TITLE
fix compile error on linux

### DIFF
--- a/subprojects/libft/src/ft_getopt.c
+++ b/subprojects/libft/src/ft_getopt.c
@@ -46,10 +46,13 @@
 
 static void	print_error(char *argv0, char *msg, char opt)
 {
-	write(STDERR_FILENO, argv0, ft_strlen(argv0));
-	write(STDERR_FILENO, msg, ft_strlen(msg));
-	write(STDERR_FILENO, &opt, 1);
-	write(STDERR_FILENO, "\n", sizeof("\n"));
+	ssize_t _;
+
+	_ = write(STDERR_FILENO, argv0, ft_strlen(argv0));
+	_ = write(STDERR_FILENO, msg, ft_strlen(msg));
+	_ = write(STDERR_FILENO, &opt, 1);
+	_ = write(STDERR_FILENO, "\n", sizeof("\n"));
+	(void)_;
 }
 
 static int	process_arg(struct s_ft_getopt *opt, char **argv)


### PR DESCRIPTION
Compile error included below:

```
../subprojects/libft/src/ft_getopt.c: In function ‘print_error’:
../subprojects/libft/src/ft_getopt.c:49:2: error: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Werror=unused-result]
   49 |  write(STDERR_FILENO, argv0, ft_strlen(argv0));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../subprojects/libft/src/ft_getopt.c:50:2: error: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Werror=unused-result]
   50 |  write(STDERR_FILENO, msg, ft_strlen(msg));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../subprojects/libft/src/ft_getopt.c:51:2: error: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Werror=unused-result]
   51 |  write(STDERR_FILENO, &opt, 1);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../subprojects/libft/src/ft_getopt.c:52:2: error: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Werror=unused-result]
   52 |  write(STDERR_FILENO, "\n", sizeof("\n"));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This compile error wasn't an actual issue in this case, as we can't
really do anything sane when the printing of errors fails. So let's
just ignore it instead.

The fix itself is kinda dirty (just casting the result to void directly
wasn't enough to silence it).