### PR TITLE
input: fix pasting

### DIFF
--- a/src/input/private.h
+++ b/src/input/private.h
@@ -60,26 +60,27 @@ struct s_term_pos		input__wrap_cursor(
 /*
 ** e_input__read_type contains the type of input that was read by read(2).
 **
-** INPUT__READ_TYPE_NONE:
-**     Nothing was read.
-** INPUT__READ_TYPE_REG:
-**     Just a normal character, like 'a', '$', and '\n'.
-** INPUT__READ_TYPE_ESC:
-**     A character prefixed by the '\x1b[' escape sequence.
-** INPUT__READ_TYPE_ESC_SQL:
-**     A character prefixed by the '\x1b[' escape sequence and suffixed by a
-**     '~'.
+** Some special types include:
+**
+** INPUT__READ_NONE
+**     Either nothing was read or something unrecognized was read.
+** INPUT__READ_TEXT
+**     Just a normal character, like 'a' and '$'.
 */
 enum					e_input__read_type
 {
-	INPUT__READ_TYPE_NONE,
-	INPUT__READ_TYPE_REG,
-	INPUT__READ_TYPE_ESC,
-	INPUT__READ_TYPE_ESC_SQL,
+	INPUT__READ_NONE,
+	INPUT__READ_TEXT,
+	INPUT__READ_ARROW_LEFT,
+	INPUT__READ_ARROW_RIGHT,
+	INPUT__READ_BACKSPACE,
+	INPUT__READ_RETURN,
 };
 
 /*
 ** s_input__keypress contains the processed input read by input__read_keypress.
+**
+** if .type == INPUT__READ_TEXT then .c contains the the char read.
 */
 struct					s_input__keypress
 {
@@ -97,7 +98,7 @@ typedef ssize_t			t_read_func(int fildes, void *buf, size_t nbyte);
 ** s_input__read_keypress. seq->type will be INPUT__READ_TYPE_NONE if nothing
 ** was read.
 */
-t_error					input__read_keypress(
+int						input__read_keypress(
 							struct s_input__keypress *keypress,
 							t_read_func read_func);
 

--- a/src/input/read_keypress.c
+++ b/src/input/read_keypress.c
@@ -15,33 +15,53 @@
 
 #include "private.h"
 
-t_error					input__read_keypress(
+static int				read_char(char *c, t_read_func read_func)
+{
+	*c = '\0';
+	return (read_func(STDIN_FILENO, c, 1));
+}
+
+static int				read_escape(struct s_input__keypress *keypress,
+							t_read_func read_func)
+{
+	char c;
+
+	if (read_char(&c, read_func) == -1)
+		return (-1);
+	if (c == '[')
+	{
+		if (read_char(&c, read_func) == -1)
+			return (-1);
+		if (c == 'D')
+			keypress->type = INPUT__READ_ARROW_LEFT;
+		else if (c == 'C')
+			keypress->type = INPUT__READ_ARROW_RIGHT;
+	}
+	return (0);
+}
+
+int						input__read_keypress(
 							struct s_input__keypress *keypress,
 							t_read_func read_func)
 {
-	ssize_t				read_amount;
-	char				buffer[4 + 1];
+	char	c;
 
-	ft_memset(&buffer, '\0', sizeof(buffer));
-	read_amount = read_func(STDIN_FILENO, &buffer, sizeof(buffer) - 1);
-	if (read_amount == -1)
-		return (errorf("read syscall failed"));
-	if (read_amount == 0)
+	ft_memset(keypress, '\0', sizeof(*keypress));
+	if (read_char(&c, read_func) == -1)
+		return (-1);
+	if (c == '\x1b')
 	{
-		keypress->type = INPUT__READ_TYPE_NONE;
-		keypress->c = '\0';
+		if (read_escape(keypress, read_func) == -1)
+			return (-1);
 	}
-	else if (buffer[0] == '\x1b' && buffer[1] == '[')
+	else if (c == '\x7f')
+		keypress->type = INPUT__READ_BACKSPACE;
+	else if (c == '\n')
+		keypress->type = INPUT__READ_RETURN;
+	else if (ft_isprint(c))
 	{
-		keypress->type = buffer[3] == '~'
-			? INPUT__READ_TYPE_ESC_SQL
-			: INPUT__READ_TYPE_ESC;
-		keypress->c = buffer[2];
+		keypress->type = INPUT__READ_TEXT;
+		keypress->c = c;
 	}
-	else
-	{
-		keypress->type = INPUT__READ_TYPE_REG;
-		keypress->c = buffer[0];
-	}
-	return (error_none());
+	return (0);
 }

--- a/src/input/run_next_action.c
+++ b/src/input/run_next_action.c
@@ -33,26 +33,20 @@ static t_error					run_next_signal(struct s_input__state *state,
 	assert(!"unknown signum");
 }
 
-static bool						keypress_is(struct s_input__keypress keypress,
-									enum e_input__read_type type, char c)
-{
-	return (keypress.type == type && keypress.c == c);
-}
-
 static t_error					run_next_keypress(struct s_input__state *state,
 									struct s_input__keypress keypress)
 {
-	if (keypress_is(keypress, INPUT__READ_TYPE_ESC, 'D'))
+	if (keypress.type == INPUT__READ_ARROW_LEFT)
 		return (input__action_left(state));
-	if (keypress_is(keypress, INPUT__READ_TYPE_ESC, 'C'))
+	if (keypress.type == INPUT__READ_ARROW_RIGHT)
 		return (input__action_right(state));
-	if (keypress_is(keypress, INPUT__READ_TYPE_REG, '\x7f'))
+	if (keypress.type == INPUT__READ_BACKSPACE)
 		return (input__action_backspace(state));
-	if (keypress_is(keypress, INPUT__READ_TYPE_REG, '\n'))
+	if (keypress.type == INPUT__READ_RETURN)
 		return (input__action_return(state));
-	if (keypress.type == INPUT__READ_TYPE_REG && ft_isprint(keypress.c))
+	if (keypress.type == INPUT__READ_TEXT)
 		return (input__action_insert(state, keypress.c));
-	return (error_none());
+	assert(!"unhandled keypress type");
 }
 
 t_error							input__run_next_action(
@@ -60,7 +54,6 @@ t_error							input__run_next_action(
 									bool *did_invalidate,
 									t_read_func read_func)
 {
-	t_error						error;
 	int							signum;
 	struct s_input__keypress	keypress;
 
@@ -70,10 +63,9 @@ t_error							input__run_next_action(
 	{
 		return (run_next_signal(state, signum));
 	}
-	error = input__read_keypress(&keypress, read_func);
-	if (is_error(error))
-		return (errorf("failed to read sequence: %s", error.msg));
-	if (keypress.type != INPUT__READ_TYPE_NONE)
+	if (input__read_keypress(&keypress, read_func) == -1)
+		return (errorf("failed to read keypress"));
+	if (keypress.type != INPUT__READ_NONE)
 	{
 		return (run_next_keypress(state, keypress));
 	}

--- a/src/input/run_next_action_test.c
+++ b/src/input/run_next_action_test.c
@@ -41,19 +41,16 @@ Test(input__run_next_action, keypress) {
 	free(state.buffer);
 }
 
-char *keypresses_build_message[] = {
-	"H", "e", "l", "l", "o", " ", "o", "r", "l", "d", "!",
-	"\x1b[D", "\x1b[D", "\x1b[D", "\x1b[D", "\x1b[D", "\x1b[D", ",",
-	"\x1b[C", "W",
-};
+size_t index_build_message = 0;
+
+char keypresses_build_message[] =
+	"Hello orld!\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D,\x1b[CW";
 
 ssize_t fake_read_build_message(int fd, void *buf, size_t count) {
-	static int i = 0;
 	cr_expect_eq(fd, STDIN_FILENO);
-	ft_strlcpy(buf, keypresses_build_message[i], count);
-	size_t ret = strlen(keypresses_build_message[i]);
-	i++;
-	return (ret);
+	strncpy(buf, keypresses_build_message + index_build_message, count);
+	index_build_message += count;
+	return (count);
 }
 
 Test(input__run_next_action, build_message) {
@@ -62,9 +59,7 @@ Test(input__run_next_action, build_message) {
 		.cursor_position = 0,
 	};
 
-	for (size_t i = 0;
-		i < sizeof(keypresses_build_message) / sizeof(*keypresses_build_message);
-		i++)
+	while (index_build_message < strlen(keypresses_build_message))
 	{
 		bool did_invalidate = false;
 		t_error error = input__run_next_action(

--- a/src/input/run_next_action_test.c
+++ b/src/input/run_next_action_test.c
@@ -117,3 +117,25 @@ Test(input__run_next_action, backspace) {
 
 	free(state.buffer);
 }
+
+ssize_t fake_read_error(int fd, void *buf, size_t count) {
+	(void)fd;
+	(void)buf;
+	(void)count;
+	return (-1);
+}
+
+Test(input__run_next_action, read_fails) {
+	struct s_input__state state = {
+		.buffer = strdup("hi"),
+		.cursor_position = 2,
+	};
+	bool did_invalidate = false;
+
+	t_error error = input__run_next_action(&state, &did_invalidate,
+		fake_read_error);
+
+	cr_expect_str_eq(error.msg, "failed to read keypress");
+
+	free(state.buffer);
+}


### PR DESCRIPTION
Previously the input__read_keypress function read 4 bytes at once,
assuming that a regular character would only be in the first byte
because a user couldn't type so fast. This assumption was flawed as
pasting text would cause all 4 bytes to be filled with data. The result
would be that, if pasting text, some but not all characters would
actually be recorded.

This patch switches to a new system which reads the input byte by byte
instead. This will also allow parsing of more complex control codes in
the future.

Fixes #18 
