### PR TITLE
input: fix graphical glitch when terminal scrolls up

### DIFF
--- a/src/bootstrap/tosh.c
+++ b/src/bootstrap/tosh.c
@@ -14,7 +14,6 @@
 #include <ft_printf.h>
 #include <unistd.h>
 #include "../error/error.h"
-#include "../term/term.h"
 #include "../input/input.h"
 
 /*
@@ -27,16 +26,11 @@ void	tosh(void)
 	t_error				error;
 	char				prompt[32];
 
-	if (term_init(getenv("TERM")) == -1)
-	{
-		ft_dprintf(STDERR_FILENO, "tosh: fatal: unknown terminal\n");
-		exit(1);
-	}
 	ft_snprintf(prompt, sizeof(prompt), "%{green}TOSH $ %{reset}");
 	while (true)
 	{
 		error = input_read(&input,
-			(struct s_input_formatted_string){prompt, 7});
+			(struct s_term_formatted_string){prompt, 7});
 		if (is_error(error))
 		{
 			ft_dprintf(STDERR_FILENO, "tosh: fatal: unable to read input: %s\n",

--- a/src/input/action_resize.c
+++ b/src/input/action_resize.c
@@ -10,18 +10,9 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef PRIVATE_H
-# define PRIVATE_H
+#include "private.h"
 
-# include "term.h"
-
-void		term__send(const char *entry);
-t_error		term__getcursor(struct s_term_pos *out);
-
-t_error		term__handle_resize(t_term *self);
-void		term__cursor_goto(t_term *self, struct s_term_pos new_pos);
-void		term__print(t_term *self,
-				struct s_term_formatted_string formatted_string);
-void		term__clear_to_end(void);
-
-#endif
+t_error		input__action_resize(t_term *term)
+{
+	return (term->handle_resize(term));
+}

--- a/src/input/configure.c
+++ b/src/input/configure.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include "private.h"
 
@@ -35,6 +36,7 @@ static void						handle_sigwinch(int signum)
 */
 
 t_error							input__configure(
+									t_term **term,
 									enum e_input__configure_action action)
 {
 	t_error			error;
@@ -42,17 +44,16 @@ t_error							input__configure(
 
 	if (action == INPUT__CONFIGURE_SETUP)
 	{
-		error = term_configure(TERM_CONFIGURE_SETUP);
+		error = term_setup(term, getenv("TERM"));
 		if (is_error(error))
 			return (errorf("failed to setup terminal: %s", error.msg));
 		g_input__sigwinch = 0;
 		prev_handler_sigwinch = signal(SIGWINCH, handle_sigwinch);
 		assert(prev_handler_sigwinch != SIG_ERR);
-		term_cursor_move(TERM_MOVE_SAVE);
 	}
 	else
 	{
-		error = term_configure(TERM_CONFIGURE_RESTORE);
+		error = term_restore(term);
 		if (is_error(error))
 			return (errorf("failed to restore terminal: %s", error.msg));
 		assert(signal(SIGWINCH, prev_handler_sigwinch) != SIG_ERR);

--- a/src/input/debug.c
+++ b/src/input/debug.c
@@ -39,8 +39,9 @@ static t_error	print_input(void)
 int				input_debug(void)
 {
 	t_error				error;
+	t_term				*term;
 
-	error = input__configure(INPUT__CONFIGURE_SETUP);
+	error = input__configure(&term, INPUT__CONFIGURE_SETUP);
 	if (is_error(error))
 	{
 		return (ft_eprintf(1, "tosh: failed to configure terminal for "
@@ -49,7 +50,7 @@ int				input_debug(void)
 	error = print_input();
 	if (is_error(error))
 		return (ft_eprintf(1, "tosh: %s\n", error.msg));
-	error = input__configure(INPUT__CONFIGURE_RESTORE);
+	error = input__configure(&term, INPUT__CONFIGURE_RESTORE);
 	if (is_error(error))
 	{
 		return (ft_eprintf(1, "tosh: failed to restore terminal to previous "

--- a/src/input/draw.c
+++ b/src/input/draw.c
@@ -17,37 +17,16 @@
 #include "../term/term.h"
 #include "private.h"
 
-static void	reposition_cursor(struct s_term_pos dest)
+void		input__draw(
+				struct s_input__state state,
+				t_term *term,
+				struct s_term_formatted_string prompt)
 {
-	size_t	amount_to_move;
-	size_t	i;
-
-	term_cursor_move(TERM_MOVE_RESTORE);
-	amount_to_move = dest.row;
-	i = 0;
-	while (i < amount_to_move)
-	{
-		term_cursor_move(TERM_MOVE_DOWN);
-		i++;
-	}
-	amount_to_move = dest.column;
-	i = 0;
-	while (i < amount_to_move)
-	{
-		term_cursor_move(TERM_MOVE_RIGHT);
-		i++;
-	}
-}
-
-void		input__draw(struct s_input__state state,
-				struct s_input_formatted_string prompt)
-{
-	struct s_term_pos	cursor_pos;
-
-	reposition_cursor((struct s_term_pos){0, 0});
-	term_clear_to_end();
-	ft_dprintf(STDERR_FILENO, "%s%s", prompt.string, state.buffer);
-	cursor_pos = input__wrap_cursor(state.terminal_columns, prompt.width,
-			state.cursor_position);
-	reposition_cursor(cursor_pos);
+	term->cursor_goto(term, term->saved_pos);
+	term->clear_to_end();
+	term->print(term, prompt);
+	term->print(term, (struct s_term_formatted_string){
+		state.buffer, ft_strlen(state.buffer)});
+	term->cursor_goto(term, term_wrap(term->terminal_size.column,
+		term->saved_pos, prompt.width + state.cursor_position));
 }

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -14,17 +14,7 @@
 # define INPUT_H
 
 # include "../error/error.h"
-
-/*
-** s_input_formatted_string is a string with possibly control codes embedded
-** in it. The width represents the amount of columns the cursor will move
-** forward when printing the string.
-*/
-struct		s_input_formatted_string
-{
-	const char	*string;
-	size_t		width;
-};
+# include "../term/term.h"
 
 /*
 ** input_read reads a single line of input to dest. prompt contains the text to
@@ -32,7 +22,7 @@ struct		s_input_formatted_string
 **
 ** Text wrapping is handled automatically.
 */
-t_error		input_read(char **dest, struct s_input_formatted_string prompt);
+t_error		input_read(char **dest, struct s_term_formatted_string prompt);
 
 /*
 ** input_debug prints useful debug information about the current keys pressed.

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -2,19 +2,17 @@ src_files += files(
 	'action_backspace.c',
 	'action_insert.c',
 	'action_left.c',
+	'action_resize.c',
 	'action_return.c',
 	'action_right.c',
-	'action_update_width.c',
 	'configure.c',
 	'debug.c',
 	'draw.c',
 	'read.c',
 	'read_keypress.c',
 	'run_next_action.c',
-	'wrap_cursor.c',
 )
 
 test_files += files(
 	'run_next_action_test.c',
-	'wrap_cursor_test.c',
 )

--- a/src/input/private.h
+++ b/src/input/private.h
@@ -27,10 +27,10 @@ enum					e_input__configure_action
 	INPUT__CONFIGURE_RESTORE,
 };
 
-t_error					input__configure(enum e_input__configure_action action);
+t_error					input__configure(t_term **term,
+							enum e_input__configure_action action);
 
 /*
-** terminal_columns the current width of the terminal.
 ** buffer           the text that the user has entered. Does not contain line
 **                  wrapping.
 ** cursor_position  the position of the cursor relative to the buffer. Does not
@@ -39,14 +39,14 @@ t_error					input__configure(enum e_input__configure_action action);
 */
 struct					s_input__state
 {
-	size_t	terminal_columns;
 	char	*buffer;
 	size_t	cursor_position;
 	bool	finished;
 };
 
 void					input__draw(struct s_input__state state,
-							struct s_input_formatted_string prompt);
+							t_term *term,
+							struct s_term_formatted_string prompt);
 
 /*
 ** input__wrap_cursor will calculate the cursor position after the wrapping was
@@ -101,12 +101,7 @@ t_error					input__read_keypress(
 							struct s_input__keypress *keypress,
 							t_read_func read_func);
 
-/*
-** input__action_update_width reads out the width from the terminal and stores
-** it in the state.
-*/
-t_error					input__action_update_width(
-							struct s_input__state *state);
+t_error					input__action_resize(t_term *term);
 
 /*
 ** input__action_{left,right} moves the cursor by one. No action is taken if the
@@ -130,6 +125,7 @@ t_error					input__action_return(struct s_input__state *state);
 
 t_error					input__run_next_action(
 							struct s_input__state *state,
+							t_term *term,
 							bool *did_invalidate,
 							t_read_func read_func);
 

--- a/src/input/run_next_action.c
+++ b/src/input/run_next_action.c
@@ -25,11 +25,10 @@ static int						next_signal(void)
 	return (0);
 }
 
-static t_error					run_next_signal(struct s_input__state *state,
-									int signum)
+static t_error					run_next_signal(t_term *term, int signum)
 {
 	if (signum == SIGWINCH)
-		return (input__action_update_width(state));
+		return (input__action_resize(term));
 	assert(!"unknown signum");
 }
 
@@ -57,6 +56,7 @@ static t_error					run_next_keypress(struct s_input__state *state,
 
 t_error							input__run_next_action(
 									struct s_input__state *state,
+									t_term *term,
 									bool *did_invalidate,
 									t_read_func read_func)
 {
@@ -68,7 +68,7 @@ t_error							input__run_next_action(
 	signum = next_signal();
 	if (signum != 0)
 	{
-		return (run_next_signal(state, signum));
+		return (run_next_signal(term, signum));
 	}
 	error = input__read_keypress(&keypress, read_func);
 	if (is_error(error))

--- a/src/input/run_next_action_test.c
+++ b/src/input/run_next_action_test.c
@@ -31,7 +31,7 @@ Test(input__run_next_action, keypress) {
 
 	bool did_invalidate = false;
 	t_error error = input__run_next_action(
-		&state, &did_invalidate, fake_read_keypress);
+		&state, NULL, &did_invalidate, fake_read_keypress);
 
 	cr_expect_not(is_error(error));
 	cr_expect_str_eq(state.buffer, "Hello, World!");
@@ -68,7 +68,7 @@ Test(input__run_next_action, build_message) {
 	{
 		bool did_invalidate = false;
 		t_error error = input__run_next_action(
-			&state, &did_invalidate, fake_read_build_message);
+			&state, NULL, &did_invalidate, fake_read_build_message);
 		cr_expect(did_invalidate);
 		cr_expect_not(is_error(error));
 	}
@@ -94,7 +94,7 @@ Test(input__run_next_action, backspace_empty) {
 
 	bool did_invalidate = false;
 	t_error error = input__run_next_action(
-		&state, &did_invalidate, fake_read_backspace);
+		&state, NULL, &did_invalidate, fake_read_backspace);
 
 	cr_expect_not(is_error(error));
 	cr_expect_str_eq(state.buffer, "");
@@ -113,7 +113,7 @@ Test(input__run_next_action, backspace) {
 
 	bool did_invalidate = false;
 	t_error error = input__run_next_action(
-		&state, &did_invalidate, fake_read_backspace);
+		&state, NULL, &did_invalidate, fake_read_backspace);
 
 	cr_expect_not(is_error(error));
 	cr_expect_str_eq(state.buffer, "Hello, World!");

--- a/src/term/clear_to_end.c
+++ b/src/term/clear_to_end.c
@@ -12,7 +12,7 @@
 
 #include "private.h"
 
-void	term_clear_to_end(void)
+void	term__clear_to_end(void)
 {
 	term__send("cd");
 }

--- a/src/term/cursor_goto.c
+++ b/src/term/cursor_goto.c
@@ -10,14 +10,14 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <ft_printf.h>
+#include <unistd.h>
+
 #include "private.h"
 
-t_error		input__action_update_width(struct s_input__state *state)
+void				term__cursor_goto(t_term *self, struct s_term_pos new_pos)
 {
-	struct s_term_pos		term_size;
-
-	if (term_getsize(&term_size) == -1)
-		return (errorf("unable to get terminal size"));
-	state->terminal_columns = term_size.column;
-	return (error_none());
+	ft_dprintf(STDERR_FILENO, "\033[%u;%uH",
+		new_pos.row + 1, new_pos.column + 1);
+	self->cursor_pos = new_pos;
 }

--- a/src/term/getcursor.c
+++ b/src/term/getcursor.c
@@ -1,0 +1,45 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   Tosh-21Shell                                       :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: tosh <tosh@student.codam.nl>                 +#+                     */
+/*                                                   +#+                      */
+/*   Created: 1970/01/01 00:00:00 by tosh          #+#    #+#                 */
+/*   Updated: 1970/01/01 99:99:99 by tosh          ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <libft.h>
+#include <unistd.h>
+
+#include "private.h"
+
+/*
+** u7 ("User string #7") requests the cursor position to be send on xterm
+** terminals. This might break very obscure terminal emulators...
+*/
+
+t_error				term__getcursor(struct s_term_pos *out)
+{
+	char				response[16];
+	ptrdiff_t			offset;
+	int					n;
+
+	ft_memset(&response, '\0', sizeof(response));
+	term__send("u7");
+	n = read(STDIN_FILENO, &response, sizeof(response) - 1);
+	if (strncmp(response, "\033[", 2) != 0)
+		return (errorf("expected terminal response to start with \\033["));
+	out->row = ft_atoi(response + 2) - 1;
+	offset = ft_strdropwhile(response + 2, ft_isdigit) - response;
+	if (response[offset] != ';')
+		return (errorf("expected terminal response be seperated with ;"));
+	out->column = ft_atoi(response + offset + 1) - 1;
+	offset = ft_strdropwhile(response + offset + 1, ft_isdigit) - response;
+	if (response[offset] != 'R')
+		return (errorf("expected terminal response to end with R"));
+	if (n != offset + 1)
+		return (errorf("unexpected extra data at end of terminal response"));
+	return (error_none());
+}

--- a/src/term/handle_resize.c
+++ b/src/term/handle_resize.c
@@ -10,35 +10,18 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <assert.h>
-
 #include "private.h"
+#include <unistd.h>
 
-/*
-** FIXME: Crashes when prompt is bigger then terminal.
-*/
-
-struct s_term_pos	input__wrap_cursor(
-						size_t terminal_width,
-						size_t prompt_width,
-						size_t cursor_pos)
+t_error		term__handle_resize(t_term *self)
 {
-	size_t				i;
-	struct s_term_pos	pos;
+	t_error error;
 
-	assert(prompt_width <= terminal_width);
-	i = 0;
-	pos.row = 0;
-	pos.column = prompt_width;
-	while (i < cursor_pos)
-	{
-		i++;
-		pos.column++;
-		if (pos.column == terminal_width)
-		{
-			pos.column = 0;
-			pos.row++;
-		}
-	}
-	return (pos);
+	if (term_getsize(&self->terminal_size) == -1)
+		return (errorf("unable to get terminal size"));
+	term__send("rc");
+	error = term__getcursor(&self->cursor_pos);
+	if (is_error(error))
+		return (errorf("unable to get cursor position: %s", error.msg));
+	return (error_none());
 }

--- a/src/term/meson.build
+++ b/src/term/meson.build
@@ -1,10 +1,16 @@
 src_files += files(
 	'clear_to_end.c',
-	'configure.c',
-	'cursor_move.c',
+	'cursor_goto.c',
+	'getcursor.c',
 	'getsize.c',
-	'init.c',
+	'handle_resize.c',
+	'print.c',
+	'restore.c',
 	'send.c',
+	'setup.c',
+	'wrap.c',
 )
 
-test_files += files()
+test_files += files(
+	'wrap_test.c'
+)

--- a/src/term/restore.c
+++ b/src/term/restore.c
@@ -13,37 +13,16 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include "term.h"
+#include "private.h"
 #include "../error/error.h"
 
-/*
-** Modes changed:
-** - ~ECHO: Disable the printing of keypresses into the terminal.
-** - ~ICANON: Read input char-by-char instead of line-by-line.
-** - VIM = 0: Read a minimum bytes to read to 0 bytes.
-** - VTIME = 1: A maximum of 100ms per keypress;
-*/
-
-t_error		term_configure(enum e_term_configure_action action)
+t_error		term_restore(t_term **out)
 {
-	static struct termios	original;
-	struct termios			new;
+	struct termios original;
 
-	if (action == TERM_CONFIGURE_SETUP)
-	{
-		if (tcgetattr(STDIN_FILENO, &original) == -1)
-			return (errorf("tcgetattr failed"));
-		new = original;
-		new.c_lflag &= ~(ECHO | ICANON);
-		new.c_cc[VMIN] = 0;
-		new.c_cc[VTIME] = 1;
-		if (tcsetattr(STDIN_FILENO, TCSADRAIN, &new) == -1)
-			return (errorf("tcsetattr failed"));
-	}
-	else
-	{
-		if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &original) == -1)
-			return (errorf("tcsetattr failed"));
-	}
+	original = (*out)->original_termios;
+	*out = NULL;
+	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &original) == -1)
+		return (errorf("tcsetattr failed"));
 	return (error_none());
 }

--- a/src/term/setup.c
+++ b/src/term/setup.c
@@ -1,0 +1,64 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   Tosh-21Shell                                       :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: tosh <tosh@student.codam.nl>                 +#+                     */
+/*                                                   +#+                      */
+/*   Created: 1970/01/01 00:00:00 by tosh          #+#    #+#                 */
+/*   Updated: 1970/01/01 99:99:99 by tosh          ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <termios.h>
+#include <unistd.h>
+#include <term.h>
+
+#include "private.h"
+#include "../error/error.h"
+
+/*
+** Modes changed:
+** - ~ECHO: Disable the printing of keypresses into the terminal.
+** - ~ICANON: Read input char-by-char instead of line-by-line.
+** - VIM = 0: Read a minimum bytes to read to 0 bytes.
+** - VTIME = 1: A maximum of 100ms per keypress;
+*/
+
+static t_error	configure(t_term *term)
+{
+	struct termios			new;
+
+	if (tcgetattr(STDIN_FILENO, &term->original_termios) == -1)
+		return (errorf("tcgetattr failed"));
+	new = term->original_termios;
+	new.c_lflag &= ~(ECHO | ICANON);
+	new.c_cc[VMIN] = 0;
+	new.c_cc[VTIME] = 1;
+	if (tcsetattr(STDIN_FILENO, TCSADRAIN, &new) == -1)
+		return (errorf("tcsetattr failed"));
+	return (error_none());
+}
+
+t_error			term_setup(t_term **out, const char *term_env)
+{
+	t_error					error;
+	static t_term			term;
+
+	if (!tgetent(NULL, term_env))
+		return (errorf("tgetent failed: unknown $TERM"));
+	error = configure(&term);
+	if (is_error(error))
+		return (error);
+	if (term_getsize(&term.terminal_size) == -1)
+		return (errorf("failed to get terminal size"));
+	term__getcursor(&term.cursor_pos);
+	term.saved_pos = term.cursor_pos;
+	term.handle_resize = term__handle_resize;
+	term.cursor_goto = term__cursor_goto;
+	term.print = term__print;
+	term.clear_to_end = term__clear_to_end;
+	term__send("sc");
+	*out = &term;
+	return (error_none());
+}

--- a/src/term/term.h
+++ b/src/term/term.h
@@ -14,53 +14,72 @@
 # define TERM_H
 
 # include <stddef.h>
-
+# include <termios.h>
 # include "../error/error.h"
 
-struct				s_term_pos
+struct					s_term_pos
 {
 	size_t	row;
 	size_t	column;
 };
 
-enum				e_term_configure_action
+/*
+** s_term_formatted_string is a string with possibly control codes embedded
+** in it. The width represents the amount of columns the cursor will move
+** forward when printing the string.
+*/
+struct					s_term_formatted_string
 {
-	TERM_CONFIGURE_SETUP,
-	TERM_CONFIGURE_RESTORE,
+	const char	*string;
+	size_t		width;
 };
 
 /*
-** term_init loads the termcap entry. Call this before all other term_*
-** functions.
+** t_term is a class-ish for drawing to the terminal. Only one instance of
+** t_term may exist at a time. An instance can be created using term_setup and
+** most be destroyed using term_restore.
 **
-** Returns 0 on success and -1 on error.
+** The cursor position is saved on setup. It is automatically kept up-to-date
+** when using cursor_goto and print.
+**
+** Call handle_resize every time the terminal resizes. The cursor position will
+** restored to the saved position.
+**
+** clear_to_end wipes out the terminal from the cursor position to the end of
+** the terminal.
 */
-int					term_init(const char *term_env);
+typedef struct s_term	t_term;
 
-/*
-** term_configure changes the termios table in ways needed for precise terminal
-** manipulation.
-*/
-t_error				term_configure(enum e_term_configure_action action);
-
-/*
-** term_getsize gets the size of the terminal. The returned struct s_term_pos
-** is equal to the maximum cursor row and column plus 1.
-*/
-int					term_getsize(struct s_term_pos *out);
-
-void				term_clear_to_end(void);
-
-enum				e_term_move
+struct					s_term
 {
-	TERM_MOVE_UP,
-	TERM_MOVE_DOWN,
-	TERM_MOVE_LINE_START,
-	TERM_MOVE_RIGHT,
-	TERM_MOVE_SAVE,
-	TERM_MOVE_RESTORE,
+	struct s_term_pos	cursor_pos;
+	struct s_term_pos	saved_pos;
+	struct s_term_pos	terminal_size;
+	struct termios		original_termios;
+	t_error				(*handle_resize)(t_term *self);
+	void				(*cursor_goto)(t_term *self,
+							struct s_term_pos new_pos);
+	void				(*print)(t_term *self,
+							struct s_term_formatted_string formatted_string);
+	void				(*clear_to_end)(void);
 };
 
-void				term_cursor_move(enum e_term_move direction);
+/*
+** term_setup creates a initializes and saves the t_term instance. Calling this
+** function when a t_term already exists results in undefined behavior.
+*/
+t_error					term_setup(t_term **out, const char *term_env);
+
+/*
+** term_restore restores the terminal configuration to before term_setup was
+** called. t_term is always replaced with NULL and term_setup may be called
+** again, even when term_restore returns an error.
+*/
+t_error					term_restore(t_term **out);
+
+int						term_getsize(struct s_term_pos *out);
+
+struct s_term_pos		term_wrap(size_t terminal_width,
+							struct s_term_pos start, size_t width);
 
 #endif

--- a/src/term/wrap.c
+++ b/src/term/wrap.c
@@ -10,11 +10,30 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <term.h>
+#include "private.h"
 
-#include "term.h"
-
-int		term_init(const char *term_env)
+struct s_term_pos		term_wrap(size_t terminal_width,
+							struct s_term_pos start, size_t width)
 {
-	return (tgetent(NULL, term_env) == 1 ? 0 : -1);
+	size_t				i;
+	struct s_term_pos	pos;
+
+	i = 0;
+	pos = start;
+	while (i < width)
+	{
+		i++;
+		pos.column++;
+		if (pos.column == terminal_width)
+		{
+			pos.column = 0;
+			pos.row++;
+		}
+	}
+	if (pos.column == 0 && i > 0)
+	{
+		pos.row--;
+		pos.column = terminal_width;
+	}
+	return (pos);
 }

--- a/src/term/wrap_test.c
+++ b/src/term/wrap_test.c
@@ -15,20 +15,38 @@
 
 #include "private.h"
 
-Test(input__wrap_cursor, single_line) {
-	struct s_term_pos pos = input__wrap_cursor(80, 20, 40);
-	cr_expect_eq(pos.row, 0);
+Test(term_wrap, single_line) {
+	struct s_term_pos pos = term_wrap(80, (struct s_term_pos){3, 20}, 40);
+	cr_expect_eq(pos.row, 3);
 	cr_expect_eq(pos.column, 60);
 }
 
-Test(input__wrap_cursor, multi_line) {
-	struct s_term_pos pos = input__wrap_cursor(80, 20, 70);
-	cr_expect_eq(pos.row, 1);
+Test(term_wrap, multi_line) {
+	struct s_term_pos pos = term_wrap(80, (struct s_term_pos){5, 20}, 70);
+	cr_expect_eq(pos.row, 6);
 	cr_expect_eq(pos.column, 10);
 }
 
-Test(input__wrap_cursor, edge) {
-	struct s_term_pos pos = input__wrap_cursor(80, 20, 60);
-	cr_expect_eq(pos.row, 1);
-	cr_expect_eq(pos.column, 0);
+Test(term_wrap, edge) {
+	struct s_term_pos pos = term_wrap(80, (struct s_term_pos){5, 20}, 60);
+	cr_expect_eq(pos.row, 5);
+	cr_expect_eq(pos.column, 80);
+}
+
+Test(term_wrap, edge_plus_one) {
+	struct s_term_pos pos = term_wrap(80, (struct s_term_pos){5, 20}, 61);
+	cr_expect_eq(pos.row, 6);
+	cr_expect_eq(pos.column, 1);
+}
+
+Test(term_wrap, multi_line_edge) {
+	struct s_term_pos pos = term_wrap(80, (struct s_term_pos){5, 20}, 80 + 60);
+	cr_expect_eq(pos.row, 6);
+	cr_expect_eq(pos.column, 80);
+}
+
+Test(term_wrap, multi_line_edge_plus_one) {
+	struct s_term_pos pos = term_wrap(80, (struct s_term_pos){5, 20}, 80 + 61);
+	cr_expect_eq(pos.row, 7);
+	cr_expect_eq(pos.column, 1);
 }


### PR DESCRIPTION
The constant restoring to the saved position every keypress doesn't
work. The issue is that when the terminal scrolls up the saved position
isn't moved up as well. To solve this we would need to move up the saved
position every time we scroll up. With the current approach that would
require us to read out the cursor position on every keypress to check
if we there is enough space and therefore would have moved up.

Unfortunately that requires sending out an escape sequence and reading
the response. Not only is this very slow and this causes flickering,
this is also unreliable because the user may enter characters before
the escape sequence is send back.

We can't just switch to keeping track of our position ourselves because
saving the cursor position was the most reliable way we found of
restoring the cursor position after a terminal resize.

This new approach will use both techniques. We will keep track of the
cursor position ourselves when redrawing the prompt in response to a
keypress. If we get the SIGWINCH (window size change) signal we will
restore the cursor position. If we calculate at that we scrolled up
during the printing of user input, we will move the saved position up.

This new technique should work in most situations. Some cases are still
unaccounted for, like what happens if the the terminal scrolls up
because of a terminal resize, but it should be enough for 21sh.