### PR TITLE
fix gcc build

### DIFF
--- a/src/input/configure.c
+++ b/src/input/configure.c
@@ -15,7 +15,7 @@
 
 #include "private.h"
 
-extern volatile sig_atomic_t	g_input__sigwinch;
+volatile sig_atomic_t	g_input__sigwinch;
 
 static void						handle_sigwinch(int signum)
 {

--- a/src/input/private.h
+++ b/src/input/private.h
@@ -19,7 +19,7 @@
 # include "input.h"
 # include "../term/term.h"
 
-volatile sig_atomic_t	g_input__sigwinch;
+extern volatile sig_atomic_t	g_input__sigwinch;
 
 enum					e_input__configure_action
 {


### PR DESCRIPTION
I got the following error while trying to compile using GCC on Linux:

    /usr/bin/ld: tosh@exe/src_input_action_insert.c.o:/home/cyborg/dev/tosh/build/../src/input/private.h:22: multiple definition of `g_input__sigwinch'; tosh@exe/src_input_action_backspace.c.o:/home/cyborg/dev/tosh/build/../src/input/private.h:22: first defined here

The following patch has been tested on both Clang and GCC.