### PR TITLE
input: move history and copy buffer to internal static

### DIFF
--- a/src/bootstrap/tosh.c
+++ b/src/bootstrap/tosh.c
@@ -25,8 +25,6 @@
 #include "../error/error.h"
 
 /*
-** todo: replace (void)env; with the executor module
-**
 ** assert is placeholder for actual code
 */
 
@@ -58,50 +56,21 @@ static void		run_command(const char *const input, t_env *const env)
 	}
 }
 
-static void		initialize_tosh(t_env **const env,
-					struct s_input_persistent *const persistent_state,
-					char **const envp)
-{
-	t_error	error;
-
-	persistent_state->copied_text = ft_strnew(0);
-	if (persistent_state->copied_text == NULL)
-	{
-		ft_dprintf(STDERR_FILENO, "tosh: fatal: out of memory\n", error.msg);
-		exit(1);
-	}
-	error = history_create(&persistent_state->history);
-	if (is_error(error))
-	{
-		ft_dprintf(STDERR_FILENO,
-			"tosh: failed to enable history support: %s\n", error.msg);
-	}
-	*env = env_from_envp(envp);
-	if (*env == NULL)
-	{
-		ft_dprintf(STDERR_FILENO, "tosh: fatal: unable to create enviroment\n");
-		exit(1);
-	}
-}
-
-/*
-** TODO: Consider using ft_getline if TERM is unknown.
-*/
-
 void			tosh(char **envp)
 {
 	t_env						*env;
 	t_error						error;
 	struct s_input_read_result	input;
-	char						prompt[32];
-	struct s_input_persistent	persistent_state;
 
-	ft_snprintf(prompt, sizeof(prompt), "%{green}TOSH $ %{reset}");
-	initialize_tosh(&env, &persistent_state, envp);
+	env = env_from_envp(envp);
+	if (env == NULL)
+	{
+		ft_dprintf(STDERR_FILENO, "tosh: fatal: unable to create enviroment\n");
+		exit(1);
+	}
 	while (true)
 	{
-		error = input_read(&input, &persistent_state,
-			(struct s_term_formatted_string){prompt, 7});
+		error = input_read(&input, "\x1b[0;32mTOSH $ \x1b[0;0m", 7);
 		if (is_error(error))
 		{
 			ft_dprintf(STDERR_FILENO, "tosh: fatal: unable to read input: %s\n",

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -14,8 +14,6 @@
 # define INPUT_H
 
 # include "../error/error.h"
-# include "../history/history.h"
-# include "../term/term.h"
 
 /*
 ** e_input_exit_reason describes the reason input_read finished.
@@ -42,26 +40,13 @@ struct		s_input_read_result
 };
 
 /*
-** history        opaque struct for managing the history. Can be NULL for
-**                disabled history support.
-** copied_text    the text to be pasted if the user wishes so.
-*/
-
-struct		s_input_persistent
-{
-	t_history	*history;
-	char		*copied_text;
-};
-
-/*
 ** input_read reads a single line of input. prompt contains the text to
 ** display before the input.
 **
 ** Text wrapping is handled automatically.
 */
 t_error		input_read(struct s_input_read_result *dest,
-				struct s_input_persistent *persistent_state,
-				struct s_term_formatted_string prompt);
+				const char *prompt, size_t prompt_width);
 
 /*
 ** input_debug prints useful debug information about the current keys pressed.

--- a/src/input/private.h
+++ b/src/input/private.h
@@ -17,6 +17,7 @@
 # include <signal.h>
 # include <unistd.h>
 # include "input.h"
+# include "../history/history.h"
 # include "../term/term.h"
 
 extern volatile sig_atomic_t	g_input__sigwinch;
@@ -29,6 +30,18 @@ enum					e_input__configure_action
 
 t_error					input__configure(t_term **term,
 							enum e_input__configure_action action);
+
+/*
+** history        opaque struct for managing the history. Can be NULL for
+**                disabled history support.
+** copied_text    the text to be pasted if the user wishes so.
+*/
+
+struct					s_input__persistent
+{
+	t_history	*history;
+	char		*copied_text;
+};
 
 /*
 ** buffer           the text that the user has entered. Does not contain line
@@ -45,7 +58,7 @@ struct					s_input__state
 	char						*buffer;
 	size_t						cursor_position;
 	ssize_t						select_start;
-	struct s_input_persistent	*persistent;
+	struct s_input__persistent	*persistent;
 	enum e_input_exit_reason	finished;
 };
 

--- a/src/input/run_next_action_test.c
+++ b/src/input/run_next_action_test.c
@@ -157,7 +157,7 @@ ssize_t fake_read_history(int fd, void *buf, size_t count) {
 Test(input__run_next_action, history) {
 	struct s_input__state state = {
 		.buffer = strdup(""),
-		.persistent = &(struct s_input_persistent){NULL, NULL},
+		.persistent = &(struct s_input__persistent){NULL, NULL},
 		.finished = INPUT_EXIT_REASON_NONE,
 	};
 


### PR DESCRIPTION
This allows input_read to be called from completely separate locations without needing to make sure that both can access the persistent state.