### PR TITLE
fix backup fd's being too high for macOS

### DIFF
--- a/src/exec/private.h
+++ b/src/exec/private.h
@@ -52,9 +52,9 @@ struct					s_redirection_kvp{
 	t_redirect_func		*handler;
 };
 
-# define BACKUP_STDIN	1000
-# define BACKUP_STDOUT	1001
-# define BACKUP_STDERR	1002
+# define BACKUP_STDIN	0xF0
+# define BACKUP_STDOUT	0xF1
+# define BACKUP_STDERR	0xF2
 
 struct					s_program_prereq{
 	char				**argv;


### PR DESCRIPTION
Limit seems to be at 256