### PR TITLE
lexer: fix fsm norm

### DIFF
--- a/normify
+++ b/normify
@@ -13,6 +13,7 @@ for spec_file in glob("normified/src/**/*_test.c"):
   os.remove(spec_file)
 for spec_file in glob("normified/src/**/meson.build"):
   os.remove(spec_file)
+os.remove("normified/src/lexer/genfsm.py")
 
 shutil.copy("author", "normified/author")
 shutil.copy("normify.mk", "normified/Makefile")

--- a/src/lexer/genfsm.py
+++ b/src/lexer/genfsm.py
@@ -203,5 +203,5 @@ output = fsm([
 
 with open(header_file_name, 'r') as header_file:
 	header = header_file.read()
-print(header)
+print(header, end='')
 print(output, end='')


### PR DESCRIPTION
There was one extra blank line between the header and the generated code