### PR TITLE
input: fix out of bounds error

### DIFF
--- a/src/input/run_next_action.c
+++ b/src/input/run_next_action.c
@@ -44,7 +44,7 @@ t_normal_action *g_action_type_table[] = {
 	[INPUT__READ_TAB] = input__action_tab,
 };
 
-t_normal_action *g_action_control_table[] = {
+t_normal_action *g_action_control_table[128] = {
 	['A'] = input__action_max_left,
 	['D'] = input__action_done,
 	['E'] = input__action_max_right,


### PR DESCRIPTION
This can be reproduced by pressing control + z.

    TOSH $ ../src/input/run_next_action.c:70:30: runtime error: index 90 out of bounds for type 't_normal_action *[89]'
    ../src/input/run_next_action.c:70:30: runtime error: load of address 0x55d5013e5950 with insufficient space for an object of type 't_normal_action *'
    0x55d5013e5950: note: pointer points here
     00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
                  ^
    =================================================================
    ==95697==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55d5013e5950 at pc 0x55d50136705a bp 0x7ffc5a96c940 sp 0x7ffc5a96c930
    READ of size 8 at 0x55d5013e5950 thread T0
        #0 0x55d501367059 in run_next_keypress ../src/input/run_next_action.c:70
        #1 0x55d501367851 in input__run_next_action ../src/input/run_next_action.c:103
        #2 0x55d501364d42 in event_loop ../src/input/read.c:40
        #3 0x55d5013658ba in input_read ../src/input/read.c:85
        #4 0x55d50134ac66 in tosh ../src/bootstrap/tosh.c:84
        #5 0x55d501370a09 in main ../src/bootstrap/main.c:49
        #6 0x7f6c04d49001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)
        #7 0x55d50134a46d in _start (/home/cyborg/archive/42/tosh/build/tosh+0x4946d)

    0x55d5013e5950 is located 8 bytes to the right of global variable 'g_action_control_table' defined in '../src/input/run_next_action.c:47:18' (0x55d5013e5680) of size 712
    0x55d5013e5950 is located 48 bytes to the left of global variable '*.Lubsan_data0' defined in '../src/input/run_next_action.c' (0x55d5013e5980) of size 32
    SUMMARY: AddressSanitizer: global-buffer-overflow ../src/input/run_next_action.c:70 in run_next_keypress
    Shadow bytes around the buggy address:
      0x0abb20274ad0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0abb20274ae0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0abb20274af0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0abb20274b00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0abb20274b10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
    =>0x0abb20274b20: 00 00 00 00 00 00 00 00 00 f9[f9]f9 f9 f9 f9 f9
      0x0abb20274b30: 00 00 00 00 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
      0x0abb20274b40: 00 00 00 00 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
      0x0abb20274b50: 00 00 00 00 f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9
      0x0abb20274b60: 00 00 f9 f9 f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9
      0x0abb20274b70: 00 00 00 00 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa
      Freed heap region:       fd
      Stack left redzone:      f1
      Stack mid redzone:       f2
      Stack right redzone:     f3
      Stack after return:      f5
      Stack use after scope:   f8
      Global redzone:          f9
      Global init order:       f6
      Poisoned by user:        f7
      Container overflow:      fc
      Array cookie:            ac
      Intra object redzone:    bb
      ASan internal:           fe
      Left alloca redzone:     ca
      Right alloca redzone:    cb
      Shadow gap:              cc
    ==95697==ABORTING