### PR TITLE
lexer: fix memory leak

### DIFF
--- a/src/lexer/handler.c
+++ b/src/lexer/handler.c
@@ -16,17 +16,15 @@
 #include "private.h"
 
 t_error		expand_tape(char **const memory_tape,
-				char **const new_text)
+				char *const append)
 {
-	char						*holder;
+	char						*new;
 
-	if (ft_asprintf(&holder, "%s\n%s", *memory_tape, *new_text) == -1)
+	if (ft_asprintf(&new, "%s\n%s", *memory_tape, append) == -1)
 	{
-		ft_strdel(new_text);
 		return (errorf("unable to allocate memory"));
 	}
-	ft_strdel(memory_tape);
-	*memory_tape = holder;
+	ft_strreplace(memory_tape, new);
 	return (error_none());
 }
 
@@ -35,8 +33,10 @@ t_error		request_qoutation_completion(char **const memory_tape,
 {
 	struct s_input_read_result	new;
 	t_error						err;
+	bool						found_quote;
 
-	while (true)
+	found_quote = false;
+	while (!found_quote)
 	{
 		err = input_read(&new, "> ", 2);
 		if (is_error(err))
@@ -48,13 +48,13 @@ t_error		request_qoutation_completion(char **const memory_tape,
 				return (errorf("User hit Ctrl-C"));
 			return (errorf("unexpected EOF while looking for`%c'", qoute));
 		}
-		err = expand_tape(memory_tape, &new.text);
+		if (ft_strchr(new.text, qoute) != NULL)
+			found_quote = true;
+		err = expand_tape(memory_tape, new.text);
+		ft_strdel(&new.text);
 		if (is_error(err))
 			return (err);
-		if (ft_strchr(new.text, qoute) != NULL)
-			break ;
 	}
-	ft_strdel(&new.text);
 	return (error_none());
 }
 


### PR DESCRIPTION
    valgrind --leak-check=full --show-possibly-lost=no -q ./tosh
    TOSH $ foo "
    >
    > "
    tosh: foo: command not found
    ==181750== 1 bytes in 1 blocks are definitely lost in loss record 2 of 44
    ==181750==    at 0x483977F: malloc (vg_replace_malloc.c:307)
    ==181750==    by 0x1155BD: ft_memalloc (ft_memalloc.c:20)
    ==181750==    by 0x115A28: ft_strnew (ft_strnew.c:17)
    ==181750==    by 0x111CBF: event_loop (read.c:31)
    ==181750==    by 0x1121A5: input_read (read.c:84)
    ==181750==    by 0x11301D: request_qoutation_completion (handler.c:41)
    ==181750==    by 0x11331A: lexer_handler (handler.c:83)
    ==181750==    by 0x10A320: run_command (tosh.c:36)
    ==181750==    by 0x10A63D: tosh (tosh.c:93)
    ==181750==    by 0x11535A: main (main.c:49)
    ==181750==