### PR TITLE
exec: fix heredoc within pipes

### DIFF
--- a/src/exec/meson.build
+++ b/src/exec/meson.build
@@ -25,6 +25,7 @@ src_files += files(
 	'builtin/echo.c',
 	'builtin/unsetenv.c',
 	'builtin/env.c',
+	'quote_and_expansion/heredoc.c',
 	'quote_and_expansion/replacer_fsm.c',
 	'quote_and_expansion/quote_and_expansion.c',
 )

--- a/src/exec/private.h
+++ b/src/exec/private.h
@@ -116,8 +116,7 @@ t_error					redirect_out_and(t_list_meta *const tracker_lst,
 
 t_error					redirect_heredoc(t_list_meta *const tracker_lst,
 							const int first_fd,
-							const struct s_io_here *const heredoc,
-							const t_env *const env);
+							const struct s_io_here *const heredoc);
 
 /*
 **		////set_arg.h////

--- a/src/exec/quote_and_expansion/heredoc.c
+++ b/src/exec/quote_and_expansion/heredoc.c
@@ -1,0 +1,76 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   Tosh-21Shell                                       :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: tosh <tosh@student.codam.nl>                 +#+                     */
+/*                                                   +#+                      */
+/*   Created: 1970/01/01 00:00:00 by tosh          #+#    #+#                 */
+/*   Updated: 1970/01/01 99:99:99 by tosh          ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <ft_printf.h>
+
+#include "../private.h"
+#include "machine_definitions.h"
+#include "../../input/input.h"
+
+static int	expand_heredoc(char **const heredoc_contents,
+				const char *const new_addition)
+{
+	char	*holder;
+
+	if (*heredoc_contents == NULL)
+	{
+		if (ft_asprintf(&holder, "%s\n", new_addition) == -1)
+		{
+			holder = NULL;
+		}
+	}
+	else
+	{
+		if (ft_asprintf(&holder, "%s%s\n",
+			*heredoc_contents, new_addition) == -1)
+		{
+			holder = NULL;
+		}
+	}
+	if (holder == NULL)
+	{
+		return (-1);
+	}
+	ft_strreplace(heredoc_contents, holder);
+	return (0);
+}
+
+t_error		acquire_heredoc(struct s_io_here *const heredoc,
+				bool is_quoted,
+				const t_env *const env)
+{
+	struct s_input_read_result	read_return;
+	t_error						err;
+
+	while (true)
+	{
+		err = input_read(&read_return, "> ", 2);
+		if (is_error(err))
+			return (err);
+		if (read_return.exit_reason == INPUT_EXIT_REASON_CANCEL)
+			return (errorf("heredoc cancelled by ctrl-c"));
+		if (read_return.exit_reason == INPUT_EXIT_REASON_DONE ||
+				ft_strequ(read_return.text, heredoc->here_end))
+		{
+			break ;
+		}
+		if (expand_heredoc(&heredoc->contents, read_return.text) == -1)
+		{
+			err = errorf("could not allocate memory");
+		}
+		ft_strdel(&read_return.text);
+	}
+	ft_strdel(&read_return.text);
+	if (!is_error(err) && !is_quoted)
+		return (replacer_fsm(&heredoc->contents, &g_here_content_table, env));
+	return (err);
+}

--- a/src/exec/quote_and_expansion/quote_and_expansion.c
+++ b/src/exec/quote_and_expansion/quote_and_expansion.c
@@ -11,10 +11,13 @@
 /* ************************************************************************** */
 
 #include "machine_definitions.h"
+#include "quote_and_expansion.h"
 
 static t_error		expand_redirection(struct s_io_redirect *const redirect,
 						t_env *const env)
 {
+	bool is_quoted;
+
 	if (redirect->file)
 	{
 		return (replacer_fsm(&redirect->file->filename,
@@ -22,11 +25,9 @@ static t_error		expand_redirection(struct s_io_redirect *const redirect,
 	}
 	else
 	{
-		if (ft_strchr(redirect->here->here_end, '\"') != NULL ||
-			ft_strchr(redirect->here->here_end, '\'') != NULL)
-		{
-			redirect->here->was_quoted = true;
-		}
+		is_quoted = ft_strchr(redirect->here->here_end, '\"') != NULL ||
+			ft_strchr(redirect->here->here_end, '\'') != NULL;
+		acquire_heredoc(redirect->here, is_quoted, env);
 		return (replacer_fsm(&redirect->here->here_end,
 			&g_here_end_table, env));
 	}

--- a/src/exec/quote_and_expansion/quote_and_expansion.h
+++ b/src/exec/quote_and_expansion/quote_and_expansion.h
@@ -51,5 +51,8 @@ typedef struct	s_machine_def{
 t_error			replacer_fsm(char **const tape,
 					const t_machine_def *machine,
 					const t_env *const env);
+t_error			acquire_heredoc(struct s_io_here *const heredoc,
+					bool is_quoted,
+					const t_env *const env);
 
 #endif

--- a/src/exec/redirect/handle_redirections.c
+++ b/src/exec/redirect/handle_redirections.c
@@ -23,8 +23,7 @@ const struct s_redirection_kvp	g_redir_tbl[] = {
 };
 
 static t_error	redirect(t_list_meta *const tracker_lst,
-					const struct s_io_redirect *const redir,
-					const t_env *const env)
+					const struct s_io_redirect *const redir)
 {
 	int								first_fd;
 	const struct s_redirection_kvp	*redir_type;
@@ -45,7 +44,7 @@ static t_error	redirect(t_list_meta *const tracker_lst,
 			first_fd = 0;
 		if (exec__is_protected_fd(first_fd) == true)
 			return (errorf("%d is a protected fd", redir->fd));
-		return (redirect_heredoc(tracker_lst, first_fd, redir->here, env));
+		return (redirect_heredoc(tracker_lst, first_fd, redir->here));
 	}
 }
 
@@ -67,7 +66,7 @@ static t_error	recurse_prefix(t_list_meta *const tracker_lst,
 			return (err);
 		}
 	}
-	err = redirect(tracker_lst, prefix->redirect, env);
+	err = redirect(tracker_lst, prefix->redirect);
 	return (err);
 }
 
@@ -110,7 +109,7 @@ t_error			exec__handle_redirections(
 	{
 		if (suffix->redirect)
 		{
-			err = redirect(tracker_lst, suffix->redirect, env);
+			err = redirect(tracker_lst, suffix->redirect);
 			if (is_error(err))
 			{
 				return (err);

--- a/src/exec/redirect/redirect_heredoc.c
+++ b/src/exec/redirect/redirect_heredoc.c
@@ -17,92 +17,23 @@
 #include "../../input/input.h"
 #include "../quote_and_expansion/machine_definitions.h"
 
-static int	expand_heredoc(char **const heredoc_contents,
-				const char *const new_addition)
-{
-	char	*holder;
-
-	if (*heredoc_contents == NULL)
-	{
-		if (ft_asprintf(&holder, "%s\n", new_addition) == -1)
-		{
-			holder = NULL;
-		}
-	}
-	else
-	{
-		if (ft_asprintf(&holder, "%s%s\n",
-			*heredoc_contents, new_addition) == -1)
-		{
-			holder = NULL;
-		}
-	}
-	if (holder == NULL)
-	{
-		return (-1);
-	}
-	ft_strreplace(heredoc_contents, holder);
-	return (0);
-}
-
-t_error		acquire_heredoc(char **const doc_contents,
-				const struct s_io_here *const heredoc,
-				const t_env *const env)
-{
-	struct s_input_read_result	read_return;
-	t_error						err;
-
-	while (true)
-	{
-		err = input_read(&read_return, "> ", 2);
-		if (is_error(err))
-			return (err);
-		if (read_return.exit_reason == INPUT_EXIT_REASON_CANCEL)
-			return (errorf("heredoc cancelled by ctrl-c"));
-		if (read_return.exit_reason == INPUT_EXIT_REASON_DONE ||
-				ft_strequ(read_return.text, heredoc->here_end))
-		{
-			break ;
-		}
-		if (expand_heredoc(doc_contents, read_return.text) == -1)
-		{
-			err = errorf("could not allocate memory");
-		}
-		ft_strdel(&read_return.text);
-	}
-	ft_strdel(&read_return.text);
-	if (!is_error(err) && !heredoc->was_quoted)
-		return (replacer_fsm(doc_contents, &g_here_content_table, env));
-	return (err);
-}
-
 t_error		redirect_heredoc(t_list_meta *const tracker_lst,
 				const int first_fd,
-				const struct s_io_here *const heredoc,
-				const t_env *const env)
+				const struct s_io_here *const heredoc)
 {
-	char		*doc_contents;
 	int			pip[2];
 	t_error		err;
 
-	doc_contents = NULL;
-	err = acquire_heredoc(&doc_contents, heredoc, env);
-	if (is_error(err))
-	{
-		ft_strdel(&doc_contents);
-		return (err);
-	}
 	if (pipe(pip) == -1)
 	{
 		return (errorf("failed to create pipe"));
 	}
-	write(pip[write_to], doc_contents, ft_strlen(doc_contents));
+	write(pip[write_to], heredoc->contents, ft_strlen(heredoc->contents));
 	close(pip[write_to]);
 	err = exec__add_tracker(first_fd, pip[read_from], tracker_lst);
 	if (is_error(err))
 	{
 		close(pip[read_from]);
 	}
-	ft_strdel(&doc_contents);
 	return (err);
 }

--- a/src/parser/io_here.c
+++ b/src/parser/io_here.c
@@ -57,6 +57,7 @@ void						free_io_here(struct s_io_here *const io_here)
 	if (io_here)
 	{
 		free(io_here->here_end);
+		free(io_here->contents);
 		free(io_here);
 	}
 }

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -78,7 +78,7 @@ struct	s_io_file
 struct	s_io_here
 {
 	char						*here_end;
-	bool						was_quoted;
+	char						*contents;
 };
 
 t_error	parser_parse(


### PR DESCRIPTION
It used to be that using a heredoc within a pipe had no result:

    TOSH $ ls | cat <<EOF
    TOSH $

This commit fixes that by moving the heredoc requesting outside of the fork