### PR TITLE
exec: fix standalone redirection causing segv

### DIFF
--- a/src/exec/quote_and_expansion/quote_and_expansion.c
+++ b/src/exec/quote_and_expansion/quote_and_expansion.c
@@ -79,22 +79,19 @@ t_error				quote_and_expansion(struct s_pipe_sequence *ast_section,
 
 	while (ast_section)
 	{
-		err = replacer_fsm(&ast_section->simple_command->name,
-				&g_basic_table, env);
-		if (is_error(err))
+		if (ast_section->simple_command->name)
 		{
-			return (err);
+			err = replacer_fsm(&ast_section->simple_command->name,
+				&g_basic_table, env);
+			if (is_error(err))
+				return (err);
 		}
 		err = rev_iter_prefix(ast_section->simple_command->prefix, env);
 		if (is_error(err))
-		{
 			return (err);
-		}
 		err = iter_suffix(ast_section->simple_command->suffix, env);
 		if (is_error(err))
-		{
 			return (err);
-		}
 		ast_section = ast_section->pipe_sequence;
 	}
 	return (error_none());

--- a/src/exec/set_arguments.c
+++ b/src/exec/set_arguments.c
@@ -77,11 +77,14 @@ t_error			exec__set_arguments(struct s_program_prereq *const all_arg,
 		exec__clear_arguments(all_arg);
 		return (err);
 	}
-	err = initialize_arguments(all_arg, command);
-	if (is_error(err))
+	if (command->name)
 	{
-		exec__clear_arguments(all_arg);
-		return (err);
+		err = initialize_arguments(all_arg, command);
+		if (is_error(err))
+		{
+			exec__clear_arguments(all_arg);
+			return (err);
+		}
 	}
 	return (err);
 }


### PR DESCRIPTION
```
TOSH $ >foo.txt
../src/exec/quote_and_expansion/replacer_fsm.c:126:44: runtime error: load of null pointer of type 'char'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==102705==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x561b57993352 bp 0x7ffe87989710 sp 0x7ffe87988de0 T0)
==102705==The signal is caused by a READ memory access.
==102705==Hint: address points to the zero page.
    #0 0x561b57993352 in replacer_fsm ../src/exec/quote_and_expansion/replacer_fsm.c:126
    #1 0x561b5799489d in quote_and_expansion ../src/exec/quote_and_expansion/quote_and_expansion.c:82
    #2 0x561b579892ee in exec_run ../src/exec/run.c:32
    #3 0x561b5798392f in run_command ../src/bootstrap/tosh.c:48
    #4 0x561b57983de0 in tosh ../src/bootstrap/tosh.c:93
    #5 0x561b579a99f4 in main ../src/bootstrap/main.c:49
    #6 0x7fd30e722001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)
    #7 0x561b5798346d in _start (/home/cyborg/archive/42/tosh/build/tosh+0x4946d)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ../src/exec/quote_and_expansion/replacer_fsm.c:126 in replacer_fsm
==102705==ABORTING
```

Fixes #63 