### PR TITLE
exec: fix empty heredoc causing null pointer deref

### DIFF
--- a/src/exec/quote_and_expansion/heredoc.c
+++ b/src/exec/quote_and_expansion/heredoc.c
@@ -21,22 +21,8 @@ static int	expand_heredoc(char **const heredoc_contents,
 {
 	char	*holder;
 
-	if (*heredoc_contents == NULL)
-	{
-		if (ft_asprintf(&holder, "%s\n", new_addition) == -1)
-		{
-			holder = NULL;
-		}
-	}
-	else
-	{
-		if (ft_asprintf(&holder, "%s%s\n",
-			*heredoc_contents, new_addition) == -1)
-		{
-			holder = NULL;
-		}
-	}
-	if (holder == NULL)
+	if (ft_asprintf(&holder, "%s%s\n",
+		*heredoc_contents, new_addition) == -1)
 	{
 		return (-1);
 	}
@@ -51,6 +37,9 @@ t_error		acquire_heredoc(struct s_io_here *const heredoc,
 	struct s_input_read_result	read_return;
 	t_error						err;
 
+	heredoc->contents = ft_strnew(0);
+	if (heredoc->contents == NULL)
+		return (errorf("could not allocate memory"));
 	while (true)
 	{
 		err = input_read(&read_return, "> ", 2);
@@ -60,13 +49,9 @@ t_error		acquire_heredoc(struct s_io_here *const heredoc,
 			return (errorf("heredoc cancelled by ctrl-c"));
 		if (read_return.exit_reason == INPUT_EXIT_REASON_DONE ||
 				ft_strequ(read_return.text, heredoc->here_end))
-		{
 			break ;
-		}
 		if (expand_heredoc(&heredoc->contents, read_return.text) == -1)
-		{
 			err = errorf("could not allocate memory");
-		}
 		ft_strdel(&read_return.text);
 	}
 	ft_strdel(&read_return.text);

--- a/src/exec/quote_and_expansion/replacer_fsm.c
+++ b/src/exec/quote_and_expansion/replacer_fsm.c
@@ -19,14 +19,7 @@ static int		add_to_tape(char **const output_tape,
 {
 	char	*holder;
 
-	if (*output_tape == NULL)
-	{
-		holder = ft_strdup(new_addition);
-	}
-	else
-	{
-		holder = ft_strjoin(*output_tape, new_addition);
-	}
+	holder = ft_strjoin(*output_tape, new_addition);
 	if (holder == NULL)
 	{
 		return (-1);
@@ -122,7 +115,9 @@ t_error			replacer_fsm(char **const tape,
 	char	*new_tape;
 	t_error	err;
 
-	new_tape = NULL;
+	new_tape = ft_strnew(0);
+	if (new_tape == NULL)
+		return (errorf("unable to allocate memory"));
 	if (machine->first_state == FIRST_CHAR && **tape == '~' && \
 		((*tape)[1] == '\0' || (*tape)[1] == '/'))
 	{


### PR DESCRIPTION
    TOSH $ cat <<EOF
    > EOF
    ../src/exec/quote_and_expansion/replacer_fsm.c:98:32: runtime error: load of null pointer of type 'const char'
    AddressSanitizer:DEADLYSIGNAL
    =================================================================
    ==184961==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x5633fa0e5ca3 bp 0x7fff4aaeaeb0 sp 0x7fff4aaeada0 T0)
    ==184961==The signal is caused by a READ memory access.
    ==184961==Hint: address points to the zero page.
        #0 0x5633fa0e5ca3 in iter_fsm ../src/exec/quote_and_expansion/replacer_fsm.c:98
        #1 0x5633fa0e670c in replacer_fsm ../src/exec/quote_and_expansion/replacer_fsm.c:134
        #2 0x5633fa0e3574 in acquire_heredoc ../src/exec/redirect/redirect_heredoc.c:75
        #3 0x5633fa0e3856 in redirect_heredoc ../src/exec/redirect/redirect_heredoc.c:89
        #4 0x5633fa0dfb65 in redirect ../src/exec/redirect/handle_redirections.c:48
        #5 0x5633fa0e0650 in exec__handle_redirections ../src/exec/redirect/handle_redirections.c:113
        #6 0x5633fa0de6ee in exec__set_arguments ../src/exec/set_arguments.c:74
        #7 0x5633fa0df0d2 in exec__single ../src/exec/single.c:53
        #8 0x5633fa0dc6b3 in exec_run ../src/exec/run.c:40
        #9 0x5633fa0d692f in run_command ../src/bootstrap/tosh.c:48
        #10 0x5633fa0d6de0 in tosh ../src/bootstrap/tosh.c:93
        #11 0x5633fa0fc9f4 in main ../src/bootstrap/main.c:49
        #12 0x7f4475949001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)
        #13 0x5633fa0d646d in _start (/home/cyborg/archive/42/tosh/build/tosh+0x4946d)

    AddressSanitizer can not provide additional info.
    SUMMARY: AddressSanitizer: SEGV ../src/exec/quote_and_expansion/replacer_fsm.c:98 in iter_fsm
    ==184961==ABORTING