### PR TITLE
input: fix selection out of bounds when jumping through history

### DIFF
--- a/src/input/action_history_down.c
+++ b/src/input/action_history_down.c
@@ -21,6 +21,7 @@ t_error		input__action_history_down(struct s_input__state *state)
 	new_buffer = history_down(state->persistent->history);
 	if (new_buffer == NULL)
 		return (error_none());
+	input__action_select_cancel(state);
 	ft_strreplace(&state->buffer, new_buffer);
 	state->cursor_position = ft_strlen(state->buffer);
 	return (error_none());

--- a/src/input/action_history_up.c
+++ b/src/input/action_history_up.c
@@ -21,6 +21,7 @@ t_error		input__action_history_up(struct s_input__state *state)
 	new_buffer = history_up(state->persistent->history);
 	if (new_buffer == NULL)
 		return (error_none());
+	input__action_select_cancel(state);
 	ft_strreplace(&state->buffer, new_buffer);
 	state->cursor_position = ft_strlen(state->buffer);
 	return (error_none());


### PR DESCRIPTION
Steps to reproduce:

 1. enter a command like "ls -al"
 2. press return
 3. go up in history
 4. select everything from right to left
 5. go down in history while still holding shift

Result:

    $ valgrind ./tosh
    ==10929== Memcheck, a memory error detector
    ==10929== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
    ==10929== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
    ==10929== Command: ./tosh
    ==10929==
    TOSH $ tosh: ../src/input/draw.c:26: print_with_selection: Assertion `end <= ft_strlen(buffer)' failed.
    ==10929==
    ==10929== Process terminating with default action of signal 6 (SIGABRT)
    ==10929==    at 0x48E718B: raise (raise.c:51)
    ==10929==    by 0x48C6858: abort (abort.c:79)
    ==10929==    by 0x48C6728: __assert_fail_base.cold (assert.c:92)
    ==10929==    by 0x48D7F35: __assert_fail (assert.c:101)
    ==10929==    by 0x111D44: print_with_selection (draw.c:26)
    ==10929==    by 0x111F0B: input__draw (draw.c:51)
    ==10929==    by 0x112151: event_loop (read.c:43)
    ==10929==    by 0x1124B8: input_read (read.c:84)
    ==10929==    by 0x10A729: tosh (tosh.c:83)
    ==10929==    by 0x11579C: main (main.c:49)
    ==10929==
    ==10929== HEAP SUMMARY:
    ==10929==     in use at exit: 27,890 bytes in 322 blocks
    ==10929==   total heap usage: 368 allocs, 46 frees, 41,909 bytes allocated
    ==10929==
    ==10929== LEAK SUMMARY:
    ==10929==    definitely lost: 0 bytes in 0 blocks
    ==10929==    indirectly lost: 0 bytes in 0 blocks
    ==10929==      possibly lost: 8,060 bytes in 298 blocks
    ==10929==    still reachable: 19,830 bytes in 24 blocks
    ==10929==         suppressed: 0 bytes in 0 blocks
    ==10929== Rerun with --leak-check=full to see details of leaked memory
    ==10929==
    ==10929== For lists of detected and suppressed errors, rerun with: -s