### PR TITLE
tosh: treat input event loop errors as non-fatal

### DIFF
--- a/src/exec/quote_and_expansion/heredoc.c
+++ b/src/exec/quote_and_expansion/heredoc.c
@@ -46,7 +46,7 @@ t_error		acquire_heredoc(struct s_io_here *const heredoc,
 		if (is_error(err))
 			return (err);
 		if (read_return.exit_reason == INPUT_EXIT_REASON_CANCEL)
-			return (errorf("heredoc cancelled by ctrl-c"));
+			return (errorf("heredoc cancelled"));
 		if (read_return.exit_reason == INPUT_EXIT_REASON_DONE ||
 				ft_strequ(read_return.text, heredoc->here_end))
 			break ;

--- a/src/input/read.c
+++ b/src/input/read.c
@@ -85,14 +85,15 @@ t_error			input_read(struct s_input_read_result *dest,
 		(struct s_term_formatted_string){prompt, prompt_width});
 	if (is_error(error))
 	{
-		input__configure(&term, INPUT__CONFIGURE_RESTORE);
-		return (errorf("tosh: %s", error.msg));
+		*dest = (struct s_input_read_result){INPUT_EXIT_REASON_CANCEL, NULL};
+		ft_dprintf(STDERR_FILENO, "tosh: %s\n", error.msg);
 	}
 	error = input__configure(&term, INPUT__CONFIGURE_RESTORE);
 	if (is_error(error))
 	{
-		return (errorf("failed to restore terminal to previous state: %s",
-			error.msg));
+		ft_dprintf(STDERR_FILENO,
+			"tosh: failed to restore terminal to previous state: %s\n",
+			error.msg);
 	}
 	return (error_none());
 }

--- a/src/lexer/handler.c
+++ b/src/lexer/handler.c
@@ -45,7 +45,7 @@ t_error		request_qoutation_completion(char **const memory_tape,
 		{
 			ft_strdel(&new.text);
 			if (new.exit_reason == INPUT_EXIT_REASON_CANCEL)
-				return (errorf("User hit Ctrl-C"));
+				return (errorf("quote completion cancelled"));
 			return (errorf("unexpected EOF while looking for`%c'", qoute));
 		}
 		if (ft_strchr(new.text, qoute) != NULL)


### PR DESCRIPTION
If the user types at the same time as resizing the window the code which
reads out the current cursor position gets confused and spits out an
error. Right now this causes tosh to exit - make this error non-fatal.

Steps to reproduce:

On macOS:

 1. In iTerm2, click on Window > Zoom
 2. Start spamming random text while the zoom is in progress

On Linux:

 1. Launch two terminals
 2. Run "while true; do kill -WINCH $(pidof tosh) 2>&-; done" in one of
    them
 3. Run tosh in the other
 4. Start to type

Old result:

    $ ./tosh
    tosh: fatal: unable to read input: tosh: failed to run next action: unable to get cursor position: expected terminal response to start with \033[
    $ 

New result:

    $ ./tosh
    tosh: failed to run next action: unable to get cursor position: expected terminal response to start with \033[
    TOSH $