### PR TITLE
input: fix escape inserting ~

### DIFF
--- a/src/input/read_keypress.c
+++ b/src/input/read_keypress.c
@@ -69,6 +69,12 @@ static int						read_modifier(
 	return (0);
 }
 
+/*
+** HACK: The escape sequence CSI 3 ~ used to cause ~ to be typed as we just
+** aborted after seeing the 3. Consume the next character to fix^Whide the
+** issue.
+*/
+
 static int						read_escape(struct s_input__keypress *keypress,
 									t_read_func read_func)
 {
@@ -82,6 +88,13 @@ static int						read_escape(struct s_input__keypress *keypress,
 			return (-1);
 		if (c == '1')
 			return (read_modifier(keypress, read_func));
+		if (c == '3')
+		{
+			if (read_char(&c, read_func) == -1)
+				return (-1);
+			keypress->type = INPUT__READ_NONE;
+			return (0);
+		}
 		keypress->type = cursor_key(c);
 	}
 	return (0);


### PR DESCRIPTION
There are similar issues, for example with the F1-12 keys, but the
evaluator is most likely to come across this one, and it isn't a major
issue anyway.